### PR TITLE
Dev <-- Dev an - adding IP and port interpretation for the connect program

### DIFF
--- a/cmd/dev-cli/main.go
+++ b/cmd/dev-cli/main.go
@@ -163,6 +163,8 @@ func printNetworkConnectEventData(event *network_connect.ConnectEventData) {
 
 func printNetworkListenEventData(event *network_listen.ListenEventData) {
 	fmt.Println("#  network_Listen.ListenEventData:")
+	fmt.Printf("Fd: %d\n", event.Fd)
+	fmt.Printf("Queue: %d\n", event.Backlog)
 	j, _ := json.Marshal(event)
 	fmt.Println(string(j))
 	fmt.Println("")

--- a/cmd/dev-cli/main.go
+++ b/cmd/dev-cli/main.go
@@ -171,7 +171,20 @@ func printNetworkListenEventData(event *network_listen.ListenEventData) {
 }
 
 func printNetworkBindEventData(event *network_bind.BindEventData) {
+	addressFamily, ipAddr , portStr := event.InterpretFamilyAndIP()
 	fmt.Println("#  network_bind.BindEventData:")
+	fmt.Printf("Pid: %d\n", event.Pid)
+	fmt.Printf("Tgid: %d\n", event.Tgid)
+	fmt.Printf("Uid: %d\n", event.Uid)
+	fmt.Printf("Gid: %d\n", event.Gid)
+	fmt.Printf("Fd: %d\n", event.Fd)
+	fmt.Printf("AddressFamily: %s\n",addressFamily)
+	fmt.Printf("IPAddress: %s\n", ipAddr)
+	fmt.Printf("Port: %d\n", portStr)
+	fmt.Printf("Address length: %d\n", event.Addrlen)
+	j, _ := json.Marshal(event)
+	fmt.Println(string(j))
+	fmt.Println("")
 	j, _ := json.Marshal(event)
 	fmt.Println(string(j))
 	fmt.Println("")

--- a/cmd/dev-cli/main.go
+++ b/cmd/dev-cli/main.go
@@ -185,9 +185,6 @@ func printNetworkBindEventData(event *network_bind.BindEventData) {
 	j, _ := json.Marshal(event)
 	fmt.Println(string(j))
 	fmt.Println("")
-	j, _ := json.Marshal(event)
-	fmt.Println(string(j))
-	fmt.Println("")
 }
 
 func printNetworkAcceptEventData(event *network_accept.AcceptEventData) {

--- a/cmd/dev-cli/main.go
+++ b/cmd/dev-cli/main.go
@@ -145,7 +145,17 @@ func printProcessSocketEventData(event *network_socket.SocketEventData) {
 }
 
 func printNetworkConnectEventData(event *network_connect.ConnectEventData) {
+	addressFamily, ipAddr , portStr := event.InterpretFamilyAndIP()
 	fmt.Println("#  network_connect.ConnectEventData:")
+	fmt.Printf("Pid: %d\n", event.Pid)
+	fmt.Printf("Tgid: %d\n", event.Tgid)
+	fmt.Printf("Uid: %d\n", event.Uid)
+	fmt.Printf("Gid: %d\n", event.Gid)
+	fmt.Printf("Fd: %d\n", event.Fd)
+	fmt.Printf("Address Family: %s\n",addressFamily)
+	fmt.Printf("IPAddress: %s\n", ipAddr)
+	fmt.Printf("Port: %d\n", portStr)
+	fmt.Printf("Address Length: %d\n", event.Addrlen)
 	j, _ := json.Marshal(event)
 	fmt.Println(string(j))
 	fmt.Println("")

--- a/cmd/dev-cli/main.go
+++ b/cmd/dev-cli/main.go
@@ -176,7 +176,16 @@ func printNetworkBindEventData(event *network_bind.BindEventData) {
 }
 
 func printNetworkAcceptEventData(event *network_accept.AcceptEventData) {
+	addressFamily, ipAddr , portStr := event.InterpretFamilyAndIP()
 	fmt.Println("#  network_accept.AcceptEventData:")
+	fmt.Printf("Pid: %d\n", event.Pid)
+	fmt.Printf("Tgid: %d\n", event.Tgid)
+	fmt.Printf("Uid: %d\n", event.Uid)
+	fmt.Printf("Gid: %d\n", event.Gid)
+	fmt.Printf("Fd: %d\n", event.Fd)
+	fmt.Printf("AddressFamily: %s\n",addressFamily)
+	fmt.Printf("IPAddress: %s\n", ipAddr)
+	fmt.Printf("Port: %d\n", portStr)
 	j, _ := json.Marshal(event)
 	fmt.Println(string(j))
 	fmt.Println("")

--- a/cmd/dev-cli/main.go
+++ b/cmd/dev-cli/main.go
@@ -132,6 +132,13 @@ func printProcessExitEventData(event process_exit.ExitEventData) {
 
 func printProcessSocketEventData(event *network_socket.SocketEventData) {
 	fmt.Println("#  network_socket.SocketEventData:")
+	fmt.Printf("Pid: %d\n", event.Pid)
+	fmt.Printf("Tgid: %d\n", event.Tgid)
+	fmt.Printf("Uid: %d\n", event.Uid)
+	fmt.Printf("Gid: %d\n", event.Gid)
+	fmt.Printf("Domain: %s\n", network_socket.Domain(event.Domain))
+	fmt.Printf("Type : %s\n", network_socket.Type(event.Type))
+	fmt.Printf("Protocol: %s\n", network_socket.Protocol(event.Protocol))
 	j, _ := json.Marshal(event)
 	fmt.Println(string(j))
 	fmt.Println("")

--- a/pkg/ebpf/c/network_accept/accept.bpf.c
+++ b/pkg/ebpf/c/network_accept/accept.bpf.c
@@ -7,10 +7,32 @@
 #include "bpf_helpers.h"
 #include "bpf_core_read.h"
 
+#define AF_INET 2
+#define AF_INET6 10
+#define AF_UNIX 1
+#define MAX_UNIX_PATH 108  // standard size for UNIX paths
+
 // Structure to hold the data that will be sent as an event.
 struct event_data
 {
-    unsigned long args[3];// Array to store arguments captured by the kprobe.
+    __u32 pid;
+    __u32 tgid;
+    __u32 uid;
+    __u32 gid;
+    int fd;
+    __u16 sa_family;
+    __u16 port;  
+    struct {
+        __be32 s_addr;
+    } v4_addr;
+    struct {
+    __u8 s6_addr[16];
+    } v6_addr;
+    struct {
+        char path[MAX_UNIX_PATH];
+    } unix_addr;
+    __u32 padding2;
+
 };
 const struct event_data *unused __attribute__((unused));
 
@@ -21,6 +43,10 @@ struct
     __uint(max_entries, 1 << 24);
 } event SEC(".maps");
 
+static inline __u16 my_ntohs(__u16 port) {
+  return (port >> 8) | (port << 8);
+}
+
 // Kprobe handler for the __x64_sys_accept function.
 SEC("kprobe/__x64_sys_accept")
 /**
@@ -30,22 +56,60 @@ SEC("kprobe/__x64_sys_accept")
  */
 int kprobe_accept(struct pt_regs *ctx)
 {
-    struct event_data args = {};// Create an event_data struct to capture the arguments.
-    // Read the first argument of __x64_sys_accept and store it in args.
-    struct pt_regs *ctx2 = (struct pt_regs *)PT_REGS_PARM1(ctx);
-    bpf_probe_read(&args.args[0], sizeof(args.args[0]), &PT_REGS_PARM1(ctx2));
-
-     // Read the second argument of __x64_sys_accept and store it in args.
-    bpf_probe_read(&args.args[1], sizeof(args.args[1]), &PT_REGS_PARM2(ctx2));
-
-    // Output the event data to the  event array
-    struct event_data *task_info; // Pointer to hold the reserved space in the ring buffer
-    task_info = bpf_ringbuf_reserve(&event, sizeof(struct event_data), 0); // Reserve space in ring buffer for event data
-    if (!task_info) {
+    struct event_data *ed; // Pointer to hold the reserved space in the ring buffer
+    ed = bpf_ringbuf_reserve(&event, sizeof(struct event_data), 0); // Reserve space in ring buffer for event data
+    if (!ed) {
     return 0;
     }
-    *task_info = args; // Copy the extracted args into the reserved space
-    bpf_ringbuf_submit(task_info, 0); // Submit the event to the ring buffer for userspace to consume
+        //Process Id and Thread Group Id
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    ed->pid = pid_tgid >> 32;
+    ed->tgid = pid_tgid;
+
+        //User Id and Group Id
+    __u64 uid_gid = bpf_get_current_uid_gid();
+    ed->uid = uid_gid >> 32;
+    ed->gid = uid_gid;
+
+    // Extract the first two arguments from the pt_regs of the kprobe event
+   struct pt_regs *ctx2 = (struct pt_regs *)PT_REGS_PARM1_CORE(ctx); // Extract the first parameter
+    ed->fd=(int)PT_REGS_PARM1_CORE(ctx2);
+   struct sockaddr *uservaddr_ptr=(struct sockaddr *)PT_REGS_PARM2_CORE(ctx2);
+
+    // Determine the socket type by inspecting the sockaddr.sa_family field
+    bpf_probe_read_user(&ed->sa_family, sizeof(ed->sa_family), uservaddr_ptr);
+    bpf_printk("sa_family: %u\n", ed->sa_family);
+
+    // Handle data based on the socket type
+    switch (ed->sa_family) {
+        case AF_INET:
+        {
+            struct sockaddr_in v4;
+            bpf_probe_read_user(&v4, sizeof(v4), uservaddr_ptr);
+            ed->v4_addr.s_addr = v4.sin_addr.s_addr;
+            ed->port = my_ntohs(v4.sin_port); // Convert from network to host byte order
+            bpf_printk("IPv4 Address: %u, Port: %u\n", ed->v4_addr.s_addr, ed->port);
+        }
+            break;
+        case AF_INET6:
+        {
+        struct sockaddr_in6 v6;
+        bpf_probe_read_user(&v6, sizeof(v6), uservaddr_ptr);
+        // Copying the IPv6 address
+        #pragma unroll
+        for (int i = 0; i < 16; i++) {
+            ed->v6_addr.s6_addr[i] = v6.sin6_addr.in6_u.u6_addr8[i];
+        }
+        // Reading the IPv6 port
+        ed->port = my_ntohs(v6.sin6_port); // Convert from network to host byte order
+        bpf_printk("IPv6 Address: %u, Port: %u\n", ed->v6_addr.s6_addr, ed->port);
+        }
+            break;
+        case AF_UNIX:
+            bpf_probe_read_user(&ed->unix_addr, sizeof(struct sockaddr_un), uservaddr_ptr);
+            break;
+    }
+    bpf_ringbuf_submit(ed, 0); // Submit the event to the ring buffer for userspace to consume
     return 0;
 }
 // License information for the eBPF program.

--- a/pkg/ebpf/c/network_accept/network_accept.go
+++ b/pkg/ebpf/c/network_accept/network_accept.go
@@ -6,6 +6,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"unsafe"
 
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
@@ -14,6 +18,11 @@ import (
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -cflags $BPF_CFLAGS -target $CURR_ARCH  -type event_data accept accept.bpf.c -- -I../../../../headers
 
 // getEbpfObject loads the eBPF objects from the compiled code and returns a pointer to the acceptObjects structure.
+const (
+    AF_INET  = 2   // Adjust with your actual values
+    AF_INET6 = 10
+    AF_UNIX  = 1
+)
 func getEbpfObject() (*acceptObjects, error) {
 	var bpfObj acceptObjects
 	// Load eBPF objects from the compiled  code into bpfObj.
@@ -31,7 +40,16 @@ func getEbpfObject() (*acceptObjects, error) {
 // The intention is to use the proper Go string instead of byte arrays from C.
 // It makes it simpler to use and can generate proper json.
 type AcceptEventData struct {
-	Args [3]uint64
+	Pid      uint32
+	Tgid     uint32
+	Uid      uint32
+	Gid      uint32
+	Fd       int32
+	SaFamily uint16
+	Port     uint16
+	V4Addr   struct{ S_addr uint32 }
+	V6Addr   struct{ S6Addr [16]uint8 }
+	UnixAddr struct{ Path [108]int8 }
 }
 
 // newAcceptEventDataFromEbpf converts an EBPF accept event to an AcceptEventData. 
@@ -39,12 +57,17 @@ type AcceptEventData struct {
 // @param e - the EBPF accept event to convert to an Accept
 func newAcceptEventDataFromEbpf(e acceptEventData) *AcceptEventData {
 	evt := &AcceptEventData{
-		Args: [3]uint64{
-			e.Args[0],
-			e.Args[1],
-			e.Args[2],
-		},
-	}
+			Pid:       e.Pid,
+			Tgid:      e.Tgid,
+			Uid:       e.Uid,
+			Gid:       e.Gid,
+			Fd:        e.Fd,
+			Port:      e.Port,		
+			SaFamily:  e.SaFamily,
+			V4Addr:    e.V4Addr,
+			V6Addr:    e.V6Addr,
+			UnixAddr:  e.UnixAddr,
+		}
 	return evt
 }
 
@@ -125,6 +148,51 @@ func (o *NetworkAcceptDetector) Read() (*AcceptEventData, error) {
 // It calls the Read method internally.
 func (o *NetworkAcceptDetector) ReadAsInterface() (any, error) {
 	return o.Read()
+}
+
+// Convert IPv4 address from binary to string.
+func ipv4ToString(addr uint32) string {
+    return fmt.Sprintf("%d.%d.%d.%d", byte(addr), byte(addr>>8), byte(addr>>16), byte(addr>>24))
+}
+
+
+// Convert IPv6 address from binary to string.
+func ipv6ToString(addr [16]uint8) string {
+    b := make([]byte, 16)
+    for i := 0; i < 4; i++ {
+        val := binary.BigEndian.Uint32(addr[i*4 : (i+1)*4])
+        binary.BigEndian.PutUint32(b[i*4:], val)
+    }
+    return net.IP(b).String()
+}
+
+
+
+func byteArrayToString(b [108]int8) string {
+    return strings.TrimRight(string((*[108]byte)(unsafe.Pointer(&b))[:]), "\x00")
+}
+
+func (e *AcceptEventData) InterpretPort() uint16 {
+ return e.Port
+}
+
+func (e *AcceptEventData) InterpretFamilyAndIP() (family string, ip string, port uint16) {
+    switch e.SaFamily {
+    case AF_INET:
+        family = "AF_INET"
+        ip = ipv4ToString(e.V4Addr.S_addr)
+    case AF_INET6:
+        family = "AF_INET6"
+        ip = ipv6ToString(e.V6Addr.S6Addr)
+    case AF_UNIX:
+        family = "AF_UNIX"
+		ip = byteArrayToString(e.UnixAddr.Path) // Read the path for UNIX socket.
+    default:
+        family = "UNKNOWN"
+        ip = "N/A"
+    }
+	port = e.InterpretPort() // Get the port
+    return family, ip ,port
 }
 
 

--- a/pkg/ebpf/c/network_bind/bind.bpf.c
+++ b/pkg/ebpf/c/network_bind/bind.bpf.c
@@ -7,11 +7,34 @@
 #include "bpf_helpers.h"
 #include "bpf_core_read.h"
 
-// Define the structure for event data
-struct event_data
-{
-    unsigned long args[3];
+// Socket address family definitions
+#define AF_INET 2
+#define AF_INET6 10
+#define AF_UNIX 1
+#define MAX_UNIX_PATH 108  // standard size for UNIX paths
+
+// Define the structure for event data which contains process, user, and socket details
+struct event_data{
+    __u32 pid;  // Process ID
+    __u32 tgid; // Thread group ID
+    __u32 uid;  // User ID
+    __u32 gid;  // Group ID
+    int fd;     // File descriptor
+    int addrlen;// Address length
+    __u16 sa_family; // Socket address family
+    __u16 port;      // Port number
+    struct {
+        __be32 s_addr;  // IPv4 address
+    } v4_addr;
+    struct {
+        __u8 s6_addr[16]; // IPv6 address
+    } v6_addr;
+    struct {
+        char path[MAX_UNIX_PATH]; // UNIX socket path
+    } unix_addr;
+    __u32 padding; // Padding for alignment
 };
+
 const struct event_data *unused __attribute__((unused));
 
 // Define the ringbuff map with maximum 1 << 24 entries
@@ -20,6 +43,10 @@ struct
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 1 << 24);
 } event SEC(".maps");
+
+static inline __u16 my_ntohs(__u16 port) {
+  return (port >> 8) | (port << 8);
+}
 
 // Define the kprobe for the __x64_sys_bind function
 SEC("kprobe/__x64_sys_bind")
@@ -30,25 +57,61 @@ SEC("kprobe/__x64_sys_bind")
 */
 int kprobe_bind(struct pt_regs *ctx)
 {
-    struct event_data args = {};
-        
-    // Extract the third argument from the pt_regs of the kprobe event
-    struct pt_regs *ctx2 = (struct pt_regs *)PT_REGS_PARM1(ctx);
-
-    // Read the first argument of __x64_sys_bind and store it in args.
-    bpf_probe_read(&args.args[0], sizeof(args.args[0]), &PT_REGS_PARM1(ctx2));
-    
-    // Read the second argument of __x64_sys_bind and store it in args.
-    bpf_probe_read(&args.args[1], sizeof(args.args[1]), &PT_REGS_PARM2(ctx2));
-
-    // Output the event data to the  event array
-    struct event_data *task_info; // Pointer to hold the reserved space in the ring buffer
-    task_info = bpf_ringbuf_reserve(&event, sizeof(struct event_data), 0); // Reserve space in ring buffer for event data
-    if (!task_info) {
+    struct event_data *ed; // Pointer to hold the reserved space in the ring buffer
+    ed = bpf_ringbuf_reserve(&event, sizeof(struct event_data), 0); // Reserve space in ring buffer for event data
+    if (!ed) {
     return 0;
     }
-    *task_info = args; // Copy the extracted args into the reserved space
-    bpf_ringbuf_submit(task_info, 0); // Submit the event to the ring buffer for userspace to consume
+    //Process Id and Thread Group Id
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    ed->pid = pid_tgid >> 32;
+    ed->tgid = pid_tgid;
+
+    //User Id and Group Id
+    __u64 uid_gid = bpf_get_current_uid_gid();
+    ed->uid = uid_gid >> 32;
+    ed->gid = uid_gid;
+
+
+    // Extract the first two arguments from the pt_regs of the kprobe event
+   struct pt_regs *ctx2 = (struct pt_regs *)PT_REGS_PARM1_CORE(ctx); // Extract the first parameter
+    ed->fd=(int)PT_REGS_PARM1_CORE(ctx2);
+   struct sockaddr *uservaddr_ptr=(struct sockaddr *)PT_REGS_PARM2_CORE(ctx2);
+    ed->addrlen = (int)PT_REGS_PARM3_CORE(ctx2);
+    bpf_printk("addrlen: %d\n", ed->addrlen);
+    // Determine the socket type by inspecting the sockaddr.sa_family field
+    bpf_probe_read_user(&ed->sa_family, sizeof(ed->sa_family), uservaddr_ptr);
+    // Handle data based on the socket type
+    switch (ed->sa_family) {
+        case AF_INET:
+        {
+            struct sockaddr_in v4;
+            bpf_probe_read_user(&v4, sizeof(v4), uservaddr_ptr);
+            ed->v4_addr.s_addr = v4.sin_addr.s_addr;
+            ed->port = my_ntohs(v4.sin_port); // Convert from network to host byte order
+        }
+            break;
+        case AF_INET6:
+   {
+        struct sockaddr_in6 v6;
+        bpf_probe_read_user(&v6, sizeof(v6), uservaddr_ptr);
+        
+        // Copying the IPv6 address
+        #pragma unroll
+        for (int i = 0; i < 16; i++) {
+            ed->v6_addr.s6_addr[i] = v6.sin6_addr.in6_u.u6_addr8[i];
+        }
+        
+        // Reading the IPv6 port
+        ed->port = my_ntohs(v6.sin6_port); // Convert from network to host byte order
+    }
+            break;
+        case AF_UNIX:
+            bpf_probe_read_user(&ed->unix_addr, sizeof(struct sockaddr_un), uservaddr_ptr);
+            break;
+    }
+
+    bpf_ringbuf_submit(ed, 0); // Submit the event to the ring buffer for userspace to consume
     return 0;
 }
 

--- a/pkg/ebpf/c/network_bind/network_bind.go
+++ b/pkg/ebpf/c/network_bind/network_bind.go
@@ -6,6 +6,11 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"unsafe"
+
 
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
@@ -14,6 +19,12 @@ import (
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -cflags $BPF_CFLAGS -target $CURR_ARCH  -type event_data bind bind.bpf.c -- -I../../../../headers
 
 // getEbpfObject loads the eBPF objects and returns a pointer to the bindObjects structure.
+const (
+    AF_INET  = 2   // Adjust with your actual values
+    AF_INET6 = 10
+    AF_UNIX  = 1
+)
+
 func getEbpfObject() (*bindObjects, error) {
 	var bpfObj bindObjects
 	err := loadBindObjects(&bpfObj, nil)

--- a/pkg/ebpf/c/network_connect/connect.bpf.c
+++ b/pkg/ebpf/c/network_connect/connect.bpf.c
@@ -7,18 +7,45 @@
 #include "bpf_helpers.h"
 #include "bpf_core_read.h"
 
-// Define the structure for event data
+// Socket address family definitions
+#define AF_INET 2
+#define AF_INET6 10
+#define AF_UNIX 1
+#define MAX_UNIX_PATH 108  // standard size for UNIX paths
+
+// Define the structure for event data which contains process, user, and socket details
 struct event_data{
-    unsigned long args[3];
+    __u32 pid;  // Process ID
+    __u32 tgid; // Thread group ID
+    __u32 uid;  // User ID
+    __u32 gid;  // Group ID
+    int fd;     // File descriptor
+    int addrlen;// Address length
+    __u16 sa_family; // Socket address family
+    __u16 port;      // Port number
+    struct {
+        __be32 s_addr;  // IPv4 address
+    } v4_addr;
+    struct {
+        __u8 s6_addr[16]; // IPv6 address
+    } v6_addr;
+    struct {
+        char path[MAX_UNIX_PATH]; // UNIX socket path
+    } unix_addr;
+    __u32 padding; // Padding for alignment
 };
 const struct event_data *unused __attribute__((unused));
 
 // Define the ringbuff map with maximum 1 << 24 entries
 struct{
     __uint(type, BPF_MAP_TYPE_RINGBUF);
-    __uint(max_entries, 1 << 24);
+    __uint(max_entries, 1 << 24); // Maximum number of entries: 2^24
 } event SEC(".maps");
 
+// Utility function to convert port from network to host byte order
+static inline __u16 my_ntohs(__u16 port) {
+  return (port >> 8) | (port << 8);
+}
 // Define the kprobe for the __x64_sys_connect function
 SEC("kprobe/__x64_sys_connect")
 /**
@@ -26,24 +53,65 @@ SEC("kprobe/__x64_sys_connect")
 * This function is called when the system is about to connect. 
 */
 int kprobe_connect(struct pt_regs * ctx){
-    struct event_data args = {};
-    // Create a struct to store the event data
-    struct pt_regs *ctx2 = (struct pt_regs *)PT_REGS_PARM1(ctx);
-    
-    // Extract the first three arguments from the pt_regs of the kprobe event
-    bpf_probe_read(&args.args[0], sizeof(args.args[0]), &PT_REGS_PARM1(ctx2));
-    bpf_probe_read(&args.args[1], sizeof(args.args[1]), &PT_REGS_PARM2(ctx2));
-    bpf_probe_read(&args.args[2], sizeof(args.args[2]), &PT_REGS_PARM3(ctx2));
+   struct event_data *ed; // Pointer to hold the reserved space in the ring buffer
 
-    // Output the event data to the perf event array
-    struct event_data *task_info; // Pointer to hold the reserved space in the ring buffer
-    task_info = bpf_ringbuf_reserve(&event, sizeof(struct event_data), 0); // Reserve space in ring buffer for event data
-    if (!task_info) {
+    ed = bpf_ringbuf_reserve(&event, sizeof(struct event_data), 0); // Reserve space in ring buffer for event data
+    if (!ed) {
     return 0;
     }
-    *task_info = args; // Copy the extracted args into the reserved space
-    bpf_ringbuf_submit(task_info, 0); // Submit the event to the ring buffer for userspace to consume
-    return 0;
+     //Process Id and Thread Group Id
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    ed->pid = pid_tgid >> 32;
+    ed->tgid = pid_tgid;
+
+    //User Id and Group Id
+    __u64 uid_gid = bpf_get_current_uid_gid();
+    ed->uid = uid_gid >> 32;
+    ed->gid = uid_gid;
+    
+    // Extract the first two arguments from the pt_regs of the kprobe event
+   struct pt_regs *ctx2 = (struct pt_regs *)PT_REGS_PARM1_CORE(ctx); // Extract the first parameter
+    ed->fd=(int)PT_REGS_PARM1_CORE(ctx2);
+   struct sockaddr *uservaddr_ptr=(struct sockaddr *)PT_REGS_PARM2_CORE(ctx2);
+    ed->addrlen = (int)PT_REGS_PARM3_CORE(ctx2);
+    bpf_printk("addrlen: %d\n", ed->addrlen);
+
+    // Read the address family to determine socket type
+    bpf_probe_read_user(&ed->sa_family, sizeof(ed->sa_family), uservaddr_ptr);
+
+    // Parse data based on socket type
+    switch (ed->sa_family) {
+        case AF_INET:// For IPv4 addresses
+        {
+            struct sockaddr_in v4;
+            bpf_probe_read_user(&v4, sizeof(v4), uservaddr_ptr);
+            ed->v4_addr.s_addr = v4.sin_addr.s_addr;
+            ed->port = my_ntohs(v4.sin_port); // Convert from network to host byte order
+        }
+            break;
+        case AF_INET6:// For IPv6 addresses
+   {
+        struct sockaddr_in6 v6;
+        bpf_probe_read_user(&v6, sizeof(v6), uservaddr_ptr);
+        
+        // Copying the IPv6 address
+        #pragma unroll
+        for (int i = 0; i < 16; i++) {
+            ed->v6_addr.s6_addr[i] = v6.sin6_addr.in6_u.u6_addr8[i];
+        }
+        
+        // Reading the IPv6 port
+        ed->port = my_ntohs(v6.sin6_port); // Convert from network to host byte order
+    }
+            break;
+        case AF_UNIX:// For UNIX sockets
+            bpf_probe_read_user(&ed->unix_addr, sizeof(struct sockaddr_un), uservaddr_ptr);
+            break;
+    }
+
+    bpf_ringbuf_submit(ed, 0); // Submit the event to the ring buffer for userspace to consume
+    return 0; // Exit the kprobe
+
 }
 
 // Define the license for the BPF program

--- a/pkg/ebpf/c/network_connect/network_connect.go
+++ b/pkg/ebpf/c/network_connect/network_connect.go
@@ -57,7 +57,6 @@ type ConnectEventData struct {
 // newConnectEventDataFromEbpf creates a new ConnectEventData instance from the given eBPF data.
 func newConnectEventDataFromEbpf(e connectEventData) *ConnectEventData {
 	evt := &ConnectEventData{
-		Args: [3]uint64{
 			Pid:       e.Pid,
 			Tgid:      e.Tgid,
 			Uid:       e.Uid,
@@ -69,7 +68,6 @@ func newConnectEventDataFromEbpf(e connectEventData) *ConnectEventData {
 			V4Addr:    e.V4Addr,
 			V6Addr:    e.V6Addr,
 			UnixAddr:  e.UnixAddr,
-		},
 	}
 	return evt
 }

--- a/pkg/ebpf/c/network_connect/network_connect.go
+++ b/pkg/ebpf/c/network_connect/network_connect.go
@@ -6,6 +6,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"unsafe"
 
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
@@ -14,6 +18,12 @@ import (
 //go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -cflags $BPF_CFLAGS -target $CURR_ARCH  -type event_data connect connect.bpf.c -- -I../../../../headers
 
 // getEbpfObject loads the eBPF objects and returns a pointer to the connectObjects structure.
+const (
+    AF_INET  = 2   
+    AF_INET6 = 10
+    AF_UNIX  = 1
+)
+
 func getEbpfObject() (*connectObjects, error) {
 	var bpfObj connectObjects
 	err := loadConnectObjects(&bpfObj, nil)
@@ -30,16 +40,35 @@ func getEbpfObject() (*connectObjects, error) {
 // The intention is to use the proper Go string instead of byte arrays from C.
 // It makes it simpler to use and can generate proper json.
 type ConnectEventData struct {
-	Args [3]uint64
+	Pid      uint32
+	Tgid     uint32
+	Uid      uint32
+	Gid      uint32
+	Fd       int32
+	SaFamily uint16
+	Port     uint16
+	V4Addr   struct{ S_addr uint32 }
+	V6Addr   struct{ S6Addr [16]uint8 }
+	UnixAddr struct{ Path [108]int8 }
+	Padding2 uint32
+	Addrlen  int32
 }
 
 // newConnectEventDataFromEbpf creates a new ConnectEventData instance from the given eBPF data.
 func newConnectEventDataFromEbpf(e connectEventData) *ConnectEventData {
 	evt := &ConnectEventData{
 		Args: [3]uint64{
-			e.Args[0],
-			e.Args[1],
-			e.Args[2],
+			Pid:       e.Pid,
+			Tgid:      e.Tgid,
+			Uid:       e.Uid,
+			Gid:       e.Gid,
+			Fd:        e.Fd,
+			Addrlen:   e.Addrlen,
+			Port:      e.Port,		
+			SaFamily:  e.SaFamily,
+			V4Addr:    e.V4Addr,
+			V6Addr:    e.V6Addr,
+			UnixAddr:  e.UnixAddr,
 		},
 	}
 	return evt
@@ -118,5 +147,50 @@ func (o *NetworkConnectDetector) Read() (*ConnectEventData, error) {
 // ReadAsInterface implements Interface.
 func (o *NetworkConnectDetector) ReadAsInterface() (any, error) {
 	return o.Read()
+}
+
+// Convert IPv4 address from binary to string.
+func ipv4ToString(addr uint32) string {
+    return fmt.Sprintf("%d.%d.%d.%d", byte(addr), byte(addr>>8), byte(addr>>16), byte(addr>>24))
+}
+
+
+// Convert IPv6 address from binary to string.
+func ipv6ToString(addr [16]uint8) string {
+    b := make([]byte, 16)
+    for i := 0; i < 4; i++ {
+        val := binary.BigEndian.Uint32(addr[i*4 : (i+1)*4])
+        binary.BigEndian.PutUint32(b[i*4:], val)
+    }
+    return net.IP(b).String()
+}
+
+
+
+func byteArrayToString(b [108]int8) string {
+    return strings.TrimRight(string((*[108]byte)(unsafe.Pointer(&b))[:]), "\x00")
+}
+
+func (e *ConnectEventData) InterpretPort() uint16 {
+ return e.Port
+}
+
+func (e *ConnectEventData) InterpretFamilyAndIP() (family string, ip string, port uint16) {
+    switch e.SaFamily {
+    case AF_INET:
+        family = "AF_INET"
+        ip = ipv4ToString(e.V4Addr.S_addr)
+    case AF_INET6:
+        family = "AF_INET6"
+        ip = ipv6ToString(e.V6Addr.S6Addr)
+    case AF_UNIX:
+        family = "AF_UNIX"
+		ip = byteArrayToString(e.UnixAddr.Path) // Read the path for UNIX socket.
+    default:
+        family = "UNKNOWN"
+        ip = "N/A"
+    }
+	port = e.InterpretPort() // Get the port
+    return family, ip ,port
 }
 

--- a/pkg/ebpf/c/network_listen/listen.bpf.c
+++ b/pkg/ebpf/c/network_listen/listen.bpf.c
@@ -9,7 +9,12 @@
 
 struct event_data
 {
-    unsigned long args[3];
+    __u32 pid;
+    __u32 tgid;
+    __u32 uid;
+    __u32 gid;
+    int fd;
+    int backlog; 
 };
 const struct event_data *unused __attribute__((unused));
 // Define the ringbuff map with maximum 1 << 24 entries
@@ -27,24 +32,26 @@ SEC("kprobe/__x64_sys_listen")
  */
 int kprobe_listen(struct pt_regs *ctx)
 {
-    struct event_data args = {};
-    
-    struct pt_regs *ctx2 = (struct pt_regs *)PT_REGS_PARM1(ctx);
-   
-    // Read the first argument of __x64_sys_listen and store it in args.
-    bpf_probe_read(&args.args[0], sizeof(args.args[0]), &PT_REGS_PARM1(ctx2));
-
-    // Read the second argument of __x64_sys_listen and store it in args.
-    bpf_probe_read(&args.args[1], sizeof(args.args[1]), &PT_REGS_PARM2(ctx2));
-
-    // Output the event data to the  event array
-    struct event_data *task_info; // Pointer to hold the reserved space in the ring buffer
-    task_info = bpf_ringbuf_reserve(&event, sizeof(struct event_data), 0); // Reserve space in ring buffer for event data
-    if (!task_info) {
+    struct event_data *ed; // Pointer to hold the reserved space in the ring buffer
+    ed = bpf_ringbuf_reserve(&event, sizeof(struct event_data), 0); // Reserve space in ring buffer for event data
+    if (!ed) {
     return 0;
     }
-    *task_info = args; // Copy the extracted args into the reserved space
-    bpf_ringbuf_submit(task_info, 0); // Submit the event to the ring buffer for userspace to consume
+        //Process Id and Thread Group Id
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    ed->pid = pid_tgid >> 32;
+    ed->tgid = pid_tgid;
+
+        //User Id and Group Id
+    __u64 uid_gid = bpf_get_current_uid_gid();
+    ed->uid = uid_gid >> 32;
+    ed->gid = uid_gid;
+
+    // Extract the first two arguments from the pt_regs of the kprobe event
+   struct pt_regs *ctx2 = (struct pt_regs *)PT_REGS_PARM1_CORE(ctx); // Extract the first parameter
+    ed->fd=(int)PT_REGS_PARM1_CORE(ctx2);
+    ed->backlog=(int)PT_REGS_PARM2_CORE(ctx2);
+    bpf_ringbuf_submit(ed, 0); // Submit the event to the ring buffer for userspace to consume
     return 0;
 }
 

--- a/pkg/ebpf/c/network_listen/network_listen.go
+++ b/pkg/ebpf/c/network_listen/network_listen.go
@@ -32,17 +32,23 @@ func getEbpfObject() (*listenObjects, error) {
 // The intention is to use the proper Go string instead of byte arrays from C.
 // It makes it simpler to use and can generate proper json.
 type ListenEventData struct {
-	Args [3]uint64
+	Pid     uint32
+	Tgid    uint32
+	Uid     uint32
+	Gid     uint32
+	Fd      int32
+	Backlog int32
 }
 
 // newListenEventDataFromEbpf creates a new ListenEventData instance from the given eBPF data.
 func newListenEventDataFromEbpf(e listenEventData) *ListenEventData {
 	evt := &ListenEventData{
-		Args: [3]uint64{
-			e.Args[0],
-			e.Args[1],
-			e.Args[2],
-		},
+			Pid :    	e.Pid,
+			Tgid:     	e.Tgid,
+			Uid:      	e.Uid,
+			Gid: 		e.Gid,
+			Fd:  		e.Fd,
+			Backlog:    e.Backlog,
 	}
 	return evt
 }

--- a/pkg/ebpf/c/network_socket/network_socket.go
+++ b/pkg/ebpf/c/network_socket/network_socket.go
@@ -31,17 +31,25 @@ func getEbpfObject() (*socketObjects, error) {
 // The intention is to use the proper Go string instead of byte arrays from C.
 // It makes it simpler to use and can generate proper JSON.
 type SocketEventData struct {
+	Pid      uint32
+	Tgid     uint32
+	Uid      uint32
+	Gid      uint32
 	Domain   uint32
 	Type     uint32
-	Protocol int32
+	Protocol uint32
 }
 
 // newSocketEventDataFromEbpf creates a new SocketEventData from an EventBPF event. This is used to implement event propagation.
 func newSocketEventDataFromEbpf(e socketEventData) *SocketEventData {
 	evt := &SocketEventData{
-		Domain:   e.Domain,
-		Type:     e.Type,
-		Protocol: e.Protocol,
+		Pid:   		e.Pid,
+		Tgid:   	e.Tgid,
+		Uid:   		e.Uid,
+		Gid:   		e.Gid,
+		Domain:   	e.Domain,
+		Type:     	e.Type,
+		Protocol: 	e.Protocol,
 	}
 	return evt
 }

--- a/pkg/ebpf/c/network_socket/network_socket.go
+++ b/pkg/ebpf/c/network_socket/network_socket.go
@@ -238,7 +238,7 @@ func Type(st uint32) string {
 }
 
 // protocols contains the mapping of protocol values to their names.
-var protocols = map[int32]string{
+var protocols = map[uint32]string{
 	1:  "ICMP",
 	6:  "TCP",
 	17: "UDP",
@@ -250,7 +250,7 @@ var protocols = map[int32]string{
 // @param proto - The protocol to look up.
 // 
 // @return The name of the protocol. 
-func Protocol(proto int32) string {
+func Protocol(proto uint32) string {
 	var res string
 
 	// get the protocol name or return the protocol name

--- a/pkg/ebpf/c/network_socket/socket.bpf.c
+++ b/pkg/ebpf/c/network_socket/socket.bpf.c
@@ -16,7 +16,7 @@ struct event_data
     __u32 gid;
     __u32 domain;     // Holds the domain of the socket (e.g., AF_INET, AF_INET6)
     __u32 type;       // Holds the type of the socket (e.g., SOCK_STREAM, SOCK_DGRAM)
-    int protocol;     // Holds the protocol used by the socket (e.g., IPPROTO_TCP, IPPROTO_UDP)
+    __u32 protocol;     // Holds the protocol used by the socket (e.g., IPPROTO_TCP, IPPROTO_UDP)
 };
 const struct event_data *unused __attribute__((unused));
 
@@ -59,7 +59,7 @@ int kprobe_socket(struct pt_regs *ctx) // Function definition for the kprobe
     ed->type =(int)PT_REGS_PARM2_CORE(ctx2); // Read the type argument
     ed->protocol=(int)PT_REGS_PARM3_CORE(ctx2);// Read the protocol argument
 
-    bpf_ringbuf_submit(task_info, 0); // Submit the event to the ring buffer for userspace to consume
+    bpf_ringbuf_submit(ed, 0); // Submit the event to the ring buffer for userspace to consume
     return 0;
 }
 


### PR DESCRIPTION
## Updated  information collected  from  __sys__connect

```bash
Pid: 152381
Tgid: 152389
Uid: 1000
Gid: 1000
Fd: 28
AddressFamily: AF_INET6
IPAddress: 2001:4860:4860::8888
Port: 53
Address length: 28

#  network_connect.ConnectEventData:
Pid: 152381
Tgid: 152388
Uid: 1000
Gid: 1000
Fd: 40
AddressFamily: AF_UNIX
IPAddress: /run/systemd/resolve/io.systemd.Resolve
Port: 0
Address length: 42
{"Pid":152381,"Tgid":152388,"Uid":1000,"Gid":1000,"Fd":40,"SaFamily":1,"Port":0,"V4Addr":{"S_addr":0},"V6Addr":{"S6Addr":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"UnixAddr":{"Path":[1,0,47,114,117,110,47,115,121,115,116,101,109,100,47,114,101,115,111,108,118,101,47,105,111,46,115,121,115,116,101,109,100,46,82,101,115,111,108,118,101,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"Padding2":0,"Addrlen":42}

#  network_connect.ConnectEventData:
Pid: 1310
Tgid: 1310
Uid: 193
Gid: 193
Fd: 22
AddressFamily: AF_INET
IPAddress: 192.168.72.22
Port: 53
Address length: 16
{"Pid":1310,"Tgid":1310,"Uid":193,"Gid":193,"Fd":22,"SaFamily":2,"Port":53,"V4Addr":{"S_addr":373860544},"V6Addr":{"S6Addr":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"UnixAddr":{"Path":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"Padding2":0,"Addrlen":16}

```